### PR TITLE
Update to use k3s-root v0.6.0-rc3 xtables autodetection

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,14 @@ FROM ${UBI_IMAGE} as ubi
 
 FROM ${GO_IMAGE} as builder
 ARG TAG="" 
+ARG K3S_ROOT_VERSION=v0.6.0-rc3
 RUN apt update     && \ 
     apt upgrade -y && \ 
-    apt install -y ca-certificates git git bash rsync
+    apt install -y ca-certificates git bash rsync
+
+RUN mkdir -p /tmp/xtables && \
+    curl -L https://github.com/rancher/k3s-root/releases/download/${K3S_ROOT_VERSION}/k3s-root-xtables-amd64.tar -o /tmp/xtables/k3s-root-xtables.tar && \
+    tar -C /tmp/xtables -xvf /tmp/xtables/k3s-root-xtables.tar
 
 RUN git clone --depth=1 https://github.com/kubernetes/kubernetes.git
 RUN cd /go/kubernetes                  && \
@@ -16,9 +21,11 @@ RUN cd /go/kubernetes                  && \
     make kube-proxy
 
 FROM ubi
-RUN microdnf update -y        && \ 
-    microdnf install iptables && \
+RUN microdnf update -y        && \
+    microdnf install -y which && \ 
     rm -rf /var/cache/yum
+
+COPY --from=builder /tmp/xtables/bin/* /usr/sbin/
 
 COPY --from=builder /go/kubernetes/_output/bin/kube-proxy /usr/local/bin
 


### PR DESCRIPTION
This changes `kube-proxy` to use the `iptables` provided by `k3s-root` (`1.8.3`) rather than using the `ubi7` provided iptables. This allows for switching between nft and legacy on the fly.

https://github.com/rancher/rke2/issues/16

Signed-off-by: Chris Kim <oats87g@gmail.com>