### PR TITLE
statically linked kube-proxy

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -7,25 +7,22 @@ platform:
 
 steps:
 - name: build
-  image: rancher/hardened-build-base:v1.14.2-amd64
+  image: rancher/hardened-build-base:v1.13.15b4
   volumes:
   - name: dockersock
     path: /var/run
   commands:
   - sleep 20
-  - TAG=${DRONE_TAG} make
-  when:
-    event:
-    - tag
+  - make DRONE_TAG=${DRONE_TAG}
 
-- name: push
-  image: rancher/hardened-build-base:v1.14.2-amd64
+- name: publish
+  image: rancher/hardened-build-base:v1.13.15b4
   volumes:
   - name: dockersock
     path: /var/run
   commands:
   - docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
-  - TAG=${DRONE_TAG} make image-push
+  - make DRONE_TAG=${DRONE_TAG} image-push image-manifest
   environment:
     DOCKER_USERNAME:
       from_secret: docker_username
@@ -36,26 +33,12 @@ steps:
     - tag
 
 - name: scan
-  image: rancher/hardened-build-base:v1.14.2-amd64
+  image: rancher/hardened-build-base:v1.13.15b4
   volumes:
   - name: dockersock
     path: /var/run
   commands:
-  - TAG=${DRONE_TAG} make image-scan
-  when:
-    event:
-    - tag
-
-- name: manifest
-  image: rancher/hardened-build-base:v1.14.2-amd64
-  volumes:
-  - name: dockersock
-    path: /var/run
-  commands:
-  - TAG=${DRONE_TAG} make image-manifest
-  when:
-    event:
-    - tag
+  - make DRONE_TAG=${DRONE_TAG} image-scan
 
 services:
 - name: docker
@@ -66,5 +49,5 @@ services:
     path: /var/run
 
 volumes:
-  - name: dockersock
-    temp: {}
+- name: dockersock
+  temp: {}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,32 +1,58 @@
 ARG UBI_IMAGE=registry.access.redhat.com/ubi7/ubi-minimal:latest
-ARG GO_IMAGE=rancher/hardened-build-base:v1.14.2-amd64
-
+ARG GO_IMAGE=rancher/hardened-build-base:v1.13.15b4
 FROM ${UBI_IMAGE} as ubi
-
 FROM ${GO_IMAGE} as builder
-ARG TAG="" 
-ARG K3S_ROOT_VERSION=v0.6.0-rc3
-RUN apt update     && \ 
-    apt upgrade -y && \ 
-    apt install -y ca-certificates git bash rsync
-
-RUN mkdir -p /tmp/xtables && \
-    curl -L https://github.com/rancher/k3s-root/releases/download/${K3S_ROOT_VERSION}/k3s-root-xtables-amd64.tar -o /tmp/xtables/k3s-root-xtables.tar && \
-    tar -C /tmp/xtables -xvf /tmp/xtables/k3s-root-xtables.tar
-
-RUN git clone --depth=1 https://github.com/kubernetes/kubernetes.git
-RUN cd /go/kubernetes                  && \
-    git fetch --all --tags --prune     && \
-    git checkout tags/${TAG} -b ${TAG} && \
-    make kube-proxy
+# setup required packages
+RUN set -x \
+ && apk --no-cache add \
+    file \
+    gcc \
+    git \
+    make
+# setup the build
+ARG ARCH="amd64"
+ARG K3S_ROOT_VERSION="v0.6.0-rc3"
+ADD https://github.com/rancher/k3s-root/releases/download/${K3S_ROOT_VERSION}/k3s-root-xtables-${ARCH}.tar /opt/xtables/k3s-root-xtables.tar
+RUN tar xvf /opt/xtables/k3s-root-xtables.tar -C /opt/xtables
+ARG TAG="v1.18.8"
+ARG PKG="github.com/kubernetes/kubernetes"
+ARG SRC="github.com/kubernetes/kubernetes"
+RUN git clone --depth=1 https://${SRC}.git $GOPATH/src/${PKG}
+WORKDIR $GOPATH/src/${PKG}
+RUN git fetch --all --tags --prune
+RUN git checkout tags/${TAG} -b ${TAG}
+RUN echo 'GO_BUILD_FLAGS=" \
+         -gcflags=-trimpath=/go/src \
+         "' \
+    >> ./go-build-static
+RUN echo 'GO_LDFLAGS=" \
+         -X k8s.io/component-base/version.gitVersion=${TAG} \
+         -X k8s.io/component-base/version.gitCommit=$(git rev-parse HEAD) \
+         -X k8s.io/component-base/version.gitTreeState=clean \
+         -X k8s.io/component-base/version.buildDate=$(date -u +%Y-%m-%dT%H:%M:%SZ) \
+         -linkmode=external -extldflags \"-static -Wl,--fatal-warnings\""' \
+    >> ./go-build-static
+RUN echo 'go build ${GO_BUILD_FLAGS} -ldflags "${GO_LDFLAGS}" "${@}"' \
+    >> ./go-build-static
+## build statically linked executables
+RUN sh -ex ./go-build-static -o bin/kube-proxy ./cmd/kube-proxy
+# assert statically linked executables
+RUN echo '[ -e $1 ] && (file $1 | grep -E "executable, x86-64, .*, statically linked")' \
+    >> ./assert-static
+RUN sh -ex ./assert-static bin/kube-proxy
+RUN ./bin/kube-proxy --version
+# assert goboring symbols
+RUN echo '[ -e $1 ] && (go tool nm $1 | grep Cfunc__goboring > .boring; if [ $(wc -l <.boring) -eq 0 ]; then exit 1; fi)' \
+    >> ./assert-boring
+RUN sh -ex ./assert-boring bin/kube-proxy
+# install (with strip) to /usr/local/bin
+RUN install -s bin/* /usr/local/bin
 
 FROM ubi
 RUN microdnf update -y     && \
     microdnf install -y which \
     conntrack-tools        && \ 
     rm -rf /var/cache/yum
-
-COPY --from=builder /tmp/xtables/bin/* /usr/sbin/
-
-COPY --from=builder /go/kubernetes/_output/bin/kube-proxy /usr/local/bin
+COPY --from=builder /opt/xtables/bin/* /usr/sbin/
+COPY --from=builder /usr/local/bin/ /usr/local/bin/
 

--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,41 @@
 SEVERITIES = HIGH,CRITICAL
 
-.PHONY: all
-all:
-	docker build --build-arg TAG=$(TAG) -t rancher/hardened-kube-proxy:$(TAG) .
+ifeq ($(ARCH),)
+ARCH=$(shell go env GOARCH)
+endif
+
+ORG ?= rancher
+PKG ?= github.com/kubernetes/kubernetes
+SRC ?= github.com/kubernetes/kubernetes
+TAG ?= v1.18.8
+
+ifneq ($(DRONE_TAG),)
+TAG := $(DRONE_TAG)
+endif
+
+.PHONY: image-build
+image-build:
+	docker build \
+		--build-arg ARCH=$(ARCH) \
+		--build-arg PKG=$(PKG) \
+		--build-arg SRC=$(SRC) \
+		--build-arg TAG=$(TAG) \
+		--tag $(ORG)/hardened-flannel:$(TAG) \
+		--tag $(ORG)/hardened-flannel:$(TAG)-$(ARCH) \
+	.
 
 .PHONY: image-push
 image-push:
-	docker push rancher/hardened-kube-proxy:$(TAG) >> /dev/null
-
-.PHONY: scan
-image-scan:
-	trivy --severity $(SEVERITIES) --no-progress --skip-update --ignore-unfixed rancher/hardened-kube-proxy:$(TAG)
+	docker push $(ORG)/hardened-flannel:$(TAG)-$(ARCH)
 
 .PHONY: image-manifest
 image-manifest:
-	docker image inspect rancher/hardened-kube-proxy:$(TAG)
-	DOCKER_CLI_EXPERIMENTAL=enabled docker manifest create rancher/hardened-kube-proxy:$(TAG) \
-		$(shell docker image inspect rancher/hardened-kube-proxy:$(TAG) | jq -r '.[] | .RepoDigests[0]')
+	DOCKER_CLI_EXPERIMENTAL=enabled docker manifest create --amend \
+		$(ORG)/hardened-flannel:$(TAG) \
+		$(ORG)/hardened-flannel:$(TAG)-$(ARCH)
+	DOCKER_CLI_EXPERIMENTAL=enabled docker manifest push \
+		$(ORG)/hardened-flannel:$(TAG)
+
+.PHONY: image-scan
+image-scan:
+	trivy --severity $(SEVERITIES) --no-progress --ignore-unfixed $(ORG)/hardened-flannel:$(TAG)


### PR DESCRIPTION
Leverage new alpine-based rancher/hardened-build-base (goboring built on
alpine) while matching the upstream version of go to compile with. Also
assert everything is statically linked and assert presence of goboring
symbols prior to install-with-strip.

Addresses rancher/rke2#335
